### PR TITLE
Save plot objects needed for air zone reports

### DIFF
--- a/04_output.R
+++ b/04_output.R
@@ -262,3 +262,16 @@ for (i in seq_along(stn_plots)) {
   dev.off()
 }
 graphics.off() # Kill any hanging graphics processes
+
+## Save plot objects (giving them different names so that they are easier to
+## disambiguate from ozone map/chart in air zone reports)
+pm_ambient_summary_plot <- ambient_summary_plot
+pm_mgmt_map <- mgmt_map
+pm_mgmt_chart <- mgmt_chart
+
+save(
+  pm_ambient_summary_plot,
+  pm_mgmt_map,
+  pm_mgmt_chart,
+  file = "tmp/plots.RData"
+)


### PR DESCRIPTION
I'd like to load the plot objects in the air zone summary report. @ateucher do you have any objection to saving them like this? The ozone analysis already does this. I've renamed them before saving because the plot names are either the same (`ambient_summary_plot`) or similar (`mgmt_map`/`mgmt_chart`) to those used in the ozone analysis.